### PR TITLE
Book: Add error context section

### DIFF
--- a/src/tutorial/errors.md
+++ b/src/tutorial/errors.md
@@ -165,7 +165,7 @@ This works because `?` actually expands to code to _convert_ error types.
 
 `Box<dyn std::error::Error>` is also an interesting type.
 It's a `Box` that can contain _any_ type
-that implements the standard [Error][`std::error::Error`] trait.
+that implements the standard [`Error`][`std::error::Error`] trait.
 This means that basically all errors can be put into this box,
 so we can use `?` on all of the usual functions that return `Result`s.
 

--- a/src/tutorial/errors.md
+++ b/src/tutorial/errors.md
@@ -218,12 +218,16 @@ We don't store the original error,
 only its string representation.
 The often used [`failure`] library has a neat solution for that:
 Similar to our `CustomError` type,
-it has a `Context` type
+it has a [`Context`] type
 that contains a description as well as the original error.
-The library also brings with it an extension trait
-that adds `context()` and `with_context()` methods to `Result`.
+The library also brings with it an extension trait ([`ResultExt`])
+that adds [`context()`] and [`with_context()`] methods to `Result`.
 
 [`failure`]: https://docs.rs/failure
+[`Context`]: https://docs.rs/failure/0.1.3/failure/struct.Context.html
+[`ResultExt`]: https://docs.rs/failure/0.1.3/failure/trait.ResultExt.html
+[`context()`]: https://docs.rs/failure/0.1.3/failure/trait.ResultExt.html#tymethod.context
+[`with_context()`]: https://docs.rs/failure/0.1.3/failure/trait.ResultExt.html#tymethod.with_context
 
 To turn these wrapped error types
 into something that humans will actually want to read,


### PR DESCRIPTION
This also introduces the failure and exitfailure crates for the first
time. Ideally they are already part of the template and readers are
not surprised by them or even have to import them.

Closes #65