### PR TITLE
Minor updates around 2018 edition

### DIFF
--- a/src/in-depth/signals.md
+++ b/src/in-depth/signals.md
@@ -108,9 +108,9 @@ whenever the signal is received.
 In your application code you use
 this and other channels
 as synchronization points between threads.
-Using [crossbeam-channels] it would look something like this:
+Using [crossbeam-channel] it would look something like this:
 
-[crossbeam-channels]: https://crates.io/crates/crossbeam-channel
+[crossbeam-channel]: https://crates.io/crates/crossbeam-channel
 
 ```rust,ignore
 {{#include signals-channels.rs:1:31}}

--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -190,7 +190,7 @@ Instead of `println!(…)` we can just use `writeln!(writer, …)`.
 Now we can test for the output:
 
 ```rust,ignore
-{{#include testing/src/main.rs:34:38}}
+{{#include testing/src/main.rs:33:38}}
 ```
 
 To now use this in our application code,

--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -255,8 +255,7 @@ But we can also make our code available as a library, like this:
 1. Put the `find_matches` function into a new `src/lib.rs`.
 2. Add a `pub` in front of the `fn` (so it's `pub fn find_matches`)
    to make it something that users of our library can access.
-3. Remove `find_matches` from `src/main.rs`,
-   and instead add an `extern crate grrs;` on top.
+3. Remove `find_matches` from `src/main.rs`.
 4. In the `fn main`, prepend the call to `find_matches` with `grrs::`,
    so it's now `grrs::find_matches(…)`.
    This means it uses the function from the library we just wrote!

--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -25,8 +25,11 @@ Write that `README` before you write the code.
 
 **Aside:**
 Have a look at
-[Test-driven development](https://en.wikipedia.org/wiki/Test-driven_development) (TDD)
+[test-driven development] (TDD)
 if you haven't heard of it.
+
+[test-driven development]: https://en.wikipedia.org/wiki/Test-driven_development
+
 
 </aside>
 


### PR DESCRIPTION
- Show `#[test]` attribute in rendered code blocks in the testing section
- Drop `extern crate` in refactoring steps: Not needed anymore with the 2018 edition
- Fix minor typos