### PR TITLE
fix broken link to in-depth chapter

### DIFF
--- a/src/tutorial/packaging.md
+++ b/src/tutorial/packaging.md
@@ -290,7 +290,8 @@ has a way to generate all these files for us.
 See [this in-depth chapter][clap-man-pages]
 for more details.
 
-[clap-man-pages]: ../../in-depth/docs.html
+
+[clap-man-pages]: ../in-depth/docs.html
 
 
 ## Getting your app into package repositories


### PR DESCRIPTION
Working with local directory structure. We need to test it after merge. 