### PR TITLE
Make signals-{ctrlc,hooked} examples demonstratble

### DIFF
--- a/src/in-depth/signals-ctrlc.rs
+++ b/src/in-depth/signals-ctrlc.rs
@@ -1,7 +1,9 @@
+use std::{thread, time::Duration};
+
 fn main() {
     ctrlc::set_handler(move || {
         println!("received Ctrl+C!");
-    }).expect("Error setting Ctrl-C handler");
-
-    // ...
+    })
+    .expect("Error setting Ctrl-C handler");
+    thread::sleep(Duration::from_secs(2));
 }

--- a/src/in-depth/signals-hooked.rs
+++ b/src/in-depth/signals-hooked.rs
@@ -1,5 +1,5 @@
-use std::{error::Error, thread};
 use signal_hook::{iterator::Signals, SIGINT};
+use std::{error::Error, thread, time::Duration};
 
 fn main() -> Result<(), Box<Error>> {
     let signals = Signals::new(&[SIGINT])?;
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<Error>> {
             println!("Received signal {:?}", sig);
         }
     });
+    thread::sleep(Duration::from_secs(2));
 
     Ok(())
 }


### PR DESCRIPTION
By introducing a little sleep, it makes it possible to actually
interrupt the examples when running:

    cargo run --bin signals-{ctrlc,hooked}