### PR TITLE
Be explicit about imports

### DIFF
--- a/src/tutorial/errors.md
+++ b/src/tutorial/errors.md
@@ -220,8 +220,8 @@ into something that humans will actually want to read,
 we can further add the [`exitfailure`] crate,
 and use its type as the return type of our `main` function.
 
-First, import the crates by adding `failure = "0.1.5"` and
-`exitfailure = "0.5.1"` to the `[dependencies]` section
+Let's first import the crates by adding
+`failure = "0.1.5"` and `exitfailure = "0.5.1"` to the `[dependencies]` section
 of our `Cargo.toml` file.
 
 The full example will then look like this:

--- a/src/tutorial/errors.md
+++ b/src/tutorial/errors.md
@@ -219,6 +219,11 @@ To turn these wrapped error types
 into something that humans will actually want to read,
 we can further add the [`exitfailure`] crate,
 and use its type as the return type of our `main` function.
+
+First, import the crates by adding `failure = "0.1.5"` and
+`exitfailure = "0.5.1"` to the `[dependencies]` section
+of our `Cargo.toml` file.
+
 The full example will then look like this:
 
 [`exitfailure`]: https://docs.rs/exitfailure


### PR DESCRIPTION
Hi CLIQuE! Thanks for the book!

I know it's obvious, but I didn't register that I had to add `failure` and `exitfailure` to `Cargo.toml`, so I made it more explicit (like adding `structops` is earlier in the tutorial). Hopefully this could save someone else some time debugging why `.with_context` just doesn't exist.