### PR TITLE
Mention the need to add exitcode dependency

### DIFF
--- a/src/in-depth/exit-code.md
+++ b/src/in-depth/exit-code.md
@@ -31,6 +31,8 @@ Please see its API documentation for the possible values to use.
 One way to use it is like this:
 
 ```rust,ignore
+extern crate exitcode;
+// ...stuff for the actual work...
 fn main() {
     // ...actual work...
     match result {

--- a/src/in-depth/exit-code.md
+++ b/src/in-depth/exit-code.md
@@ -28,11 +28,10 @@ The Rust library [`exitcode`] provides these same codes,
 ready to be used in your application.
 Please see its API documentation for the possible values to use.
 
-One way to use it is like this:
+After you add the `exitcode` dependency to your `Cargo.toml`,
+you can use it like this:
 
 ```rust,ignore
-extern crate exitcode;
-// ...stuff for the actual work...
 fn main() {
     // ...actual work...
     match result {


### PR DESCRIPTION
The text does mention `exitcode` library.
Now the example source code does have it expliciet.