### PR TITLE
Misc. link additions.

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -9,6 +9,7 @@ src = "src"
 [output.html]
 curly-quotes = true
 additional-css = ["src/special-content.css"]
+git-repository-url = "https://github.com/rust-lang-nursery/cli-wg"
 
 # Linkcheck doesn't find images/SVG so it's not enabled for now
 # [output.linkcheck]

--- a/src/in-depth/config-files.md
+++ b/src/in-depth/config-files.md
@@ -8,7 +8,7 @@ for short- and long-term files.
 There are multiple solutions to this,
 some being more low-level than others.
 
-The easiest crate to use for this is [`confy`](https://crates.io/crates/confy).
+The easiest crate to use for this is [`confy`].
 It asks you for the name of your application
 and requires you to specify the config layout
 via a `struct` (that is `Serialize`, `Deserialize`)
@@ -34,6 +34,8 @@ for which you of course surrender configurability.
 But if a simple config is all you want,
 this crate might be for you!
 
+[`confy`]: https://docs.rs/confy/0.3.1/confy/
+
 ## Configuration environments
 
 <aside class="todo">
@@ -42,6 +44,8 @@ this crate might be for you!
 
 1. Evaluate crates that exist
 2. Cli-args + multiple configs + env variables
-3. Can [`configure`](https://docs.rs/configure/0.1.1/configure/) do all this? Is there a nice wrapper around it?
+3. Can [`configure`] do all this? Is there a nice wrapper around it?
 
 </aside>
+
+[`configure`]: https://docs.rs/configure/0.1.1/configure/

--- a/src/in-depth/config-files.md
+++ b/src/in-depth/config-files.md
@@ -8,7 +8,7 @@ for short- and long-term files.
 There are multiple solutions to this,
 some being more low-level than others.
 
-The easiest crate to use for this is `confy`.
+The easiest crate to use for this is [`confy`](https://crates.io/crates/confy).
 It asks you for the name of your application
 and requires you to specify the config layout
 via a `struct` (that is `Serialize`, `Deserialize`)
@@ -42,6 +42,6 @@ this crate might be for you!
 
 1. Evaluate crates that exist
 2. Cli-args + multiple configs + env variables
-3. Can `configure` do all this? Is there a nice wrapper around it?
+3. Can [`configure`](https://docs.rs/configure/0.1.1/configure/) do all this? Is there a nice wrapper around it?
 
 </aside>


### PR DESCRIPTION
This is a small update that:
- adds a git repo link at top right of page.
- adds link to confy crate in "Using config files" section.

Current header:
![old header](https://user-images.githubusercontent.com/15309567/61599027-a1a97100-abd9-11e9-8b3a-b9b80ac01a7f.png)

Updated header with git link to the [main repository](https://github.com/rust-lang-nursery/cli-wg/):
![new header with git repo link](https://user-images.githubusercontent.com/15309567/61599024-9bb39000-abd9-11e9-8dd5-a894a01a7f4f.png)

All changes are totally open to your discretion. Thanks for making such a great resource for introducing CLI implementation with Rust! : )