### PR TITLE
Update links to Rust docs (issue #156)

### DIFF
--- a/src/tutorial/cli-args.md
+++ b/src/tutorial/cli-args.md
@@ -32,8 +32,8 @@ The standard library contains the function
 The first entry (at index `0`) will be the name your program was called as (e.g. `grrs`),
 the ones that follow are what the user wrote afterwards.
 
-[`std::env::args()`]: https://doc.rust-lang.org/1.31.0/std/env/fn.args.html
-[iterator]: https://doc.rust-lang.org/1.31.0/std/iter/index.html
+[`std::env::args()`]: https://doc.rust-lang.org/1.39.0/std/env/fn.args.html
+[iterator]: https://doc.rust-lang.org/1.39.0/std/iter/index.html
 
 Getting the raw arguments this way is quite easy:
 
@@ -71,15 +71,15 @@ Let's start with this:
 This defines a new structure (a [`struct`])
 that has two fields to store data in: `pattern`, and `path`.
 
-[`struct`]: https://doc.rust-lang.org/1.31.0/book/ch05-00-structs.html
+[`struct`]: https://doc.rust-lang.org/1.39.0/book/ch05-00-structs.html
 
 <aside>
 
 **Aside:**
 [`PathBuf`] is like a [`String`] but for file system paths that works cross-platform.
 
-[`PathBuf`]: https://doc.rust-lang.org/1.31.0/std/path/struct.PathBuf.html
-[`String`]: https://doc.rust-lang.org/1.31.0/std/string/struct.String.html
+[`PathBuf`]: https://doc.rust-lang.org/1.39.0/std/path/struct.PathBuf.html
+[`String`]: https://doc.rust-lang.org/1.39.0/std/string/struct.String.html
 
 </aside>
 

--- a/src/tutorial/errors.md
+++ b/src/tutorial/errors.md
@@ -16,9 +16,9 @@ a `String`
 or an error of some type
 (in this case [`std::io::Error`]).
 
-[`read_to_string`]: https://doc.rust-lang.org/1.31.0/std/fs/fn.read_to_string.html
-[`Result`]: https://doc.rust-lang.org/1.31.0/std/result/index.html
-[`std::io::Error`]: https://doc.rust-lang.org/1.31.0/std/io/type.Result.html
+[`read_to_string`]: https://doc.rust-lang.org/1.39.0/std/fs/fn.read_to_string.html
+[`Result`]: https://doc.rust-lang.org/1.39.0/std/result/index.html
+[`std::io::Error`]: https://doc.rust-lang.org/1.39.0/std/io/type.Result.html
 
 How do you know which it is?
 Since `Result` is an `enum`,
@@ -36,7 +36,7 @@ match result {
 
 **Aside:**
 Not sure what enums are or how they work in Rust?
-[Check this chapter of the Rust book](https://doc.rust-lang.org/1.31.0/book/ch06-00-enums.html)
+[Check this chapter of the Rust book](https://doc.rust-lang.org/1.39.0/book/ch06-00-enums.html)
 to get up to speed.
 
 </aside>
@@ -164,7 +164,7 @@ that implements the standard [`Error`][`std::error::Error`] trait.
 This means that basically all errors can be put into this box,
 so we can use `?` on all of the usual functions that return `Result`s.
 
-[`std::error::Error`]: https://doc.rust-lang.org/1.31.0/std/error/trait.Error.html
+[`std::error::Error`]: https://doc.rust-lang.org/1.39.0/std/error/trait.Error.html
 
 </aside>
 

--- a/src/tutorial/impl-draft.md
+++ b/src/tutorial/impl-draft.md
@@ -26,7 +26,7 @@ It's not very pretty,
 and in the next chapter on [Nicer error reporting]
 we will look at how to improve this.
 
-[`.expect`]: https://doc.rust-lang.org/1.31.0/std/result/enum.Result.html#method.expect
+[`.expect`]: https://doc.rust-lang.org/1.39.0/std/result/enum.Result.html#method.expect
 [Nicer error reporting]:./errors.html
 
 </aside>
@@ -50,6 +50,6 @@ Find a way to optimize it!
 (One idea might be to use a [`BufReader`]
 instead of `read_to_string()`.)
 
-[`BufReader`]: https://doc.rust-lang.org/1.31.0/std/io/struct.BufReader.html
+[`BufReader`]: https://doc.rust-lang.org/1.39.0/std/io/struct.BufReader.html
 
 </aside>

--- a/src/tutorial/output.md
+++ b/src/tutorial/output.md
@@ -64,9 +64,9 @@ debug output (human-readable but targeted at developers) uses the [`Debug`] trai
 You can find more information about the syntax you can use in `println!`
 in the [documentation for the `std::fmt` module][std::fmt].
 
-[`Display`]: https://doc.rust-lang.org/1.31.0/std/fmt/trait.Display.html
-[`Debug`]: https://doc.rust-lang.org/1.31.0/std/fmt/trait.Debug.html
-[std::fmt]: https://doc.rust-lang.org/1.31.0/std/fmt/index.html
+[`Display`]: https://doc.rust-lang.org/1.39.0/std/fmt/trait.Display.html
+[`Debug`]: https://doc.rust-lang.org/1.39.0/std/fmt/trait.Debug.html
+[std::fmt]: https://doc.rust-lang.org/1.39.0/std/fmt/index.html
 
 </aside>
 
@@ -157,7 +157,7 @@ writeln!(handle, "foo: {}", 42); // add `?` if you care about errors here
 
 You can also combine the two approaches.
 
-[`BufWriter`]: https://doc.rust-lang.org/1.31.0/std/io/struct.BufWriter.html
+[`BufWriter`]: https://doc.rust-lang.org/1.39.0/std/io/struct.BufWriter.html
 
 ## Showing a progress bar
 

--- a/src/tutorial/packaging.md
+++ b/src/tutorial/packaging.md
@@ -69,8 +69,8 @@ but also what GitHub shows by default on repository pages.
 
 [crates.io]: https://crates.io/
 [crates.io account page]: https://crates.io/me
-[publishing guide]: https://doc.rust-lang.org/1.31.0/cargo/reference/publishing.html
-[cargo's manifest format]: https://doc.rust-lang.org/1.31.0/cargo/reference/manifest.html
+[publishing guide]: https://doc.rust-lang.org/1.39.0/cargo/reference/publishing.html
+[cargo's manifest format]: https://doc.rust-lang.org/1.39.0/cargo/reference/manifest.html
 
 ### How to install a binary from crates.io
 

--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -168,7 +168,7 @@ This is a [trait][trpl-traits] that abstracts over things we can write to,
 which includes strings but also `stdout`.
 
 [trpl-traits]: https://doc.rust-lang.org/book/ch10-02-traits.html
-[`std::io::Write`]: https://doc.rust-lang.org/1.31.0/std/io/trait.Write.html
+[`std::io::Write`]: https://doc.rust-lang.org/1.39.0/std/io/trait.Write.html
 
 If this is the first time you've heard "trait"
 in the context of Rust,
@@ -241,7 +241,7 @@ and uses our extracted `find_matches` function:
 {{#include testing/src/main.rs:15:23}}
 ```
 
-[stdout]: https://doc.rust-lang.org/1.31.0/std/io/fn.stdout.html
+[stdout]: https://doc.rust-lang.org/1.39.0/std/io/fn.stdout.html
 
 <aside class="note">
 
@@ -276,8 +276,8 @@ because writing can fail,
 for example when the buffer is full and cannot be expanded.
 Add error handling to `find_matches`.
 
-[`writeln!`]: https://doc.rust-lang.org/1.31.0/std/macro.writeln.html
-[`io::Result`]: https://doc.rust-lang.org/1.31.0/std/io/type.Result.html
+[`writeln!`]: https://doc.rust-lang.org/1.39.0/std/macro.writeln.html
+[`io::Result`]: https://doc.rust-lang.org/1.39.0/std/io/type.Result.html
 
 </aside>
 
@@ -325,7 +325,7 @@ If we continue to do that,
 it'll become difficult to read.
 The [module system] can help you structure and organize your code.
 
-[module system]: https://doc.rust-lang.org/1.31.0/book/ch07-00-packages-crates-and-modules.html
+[module system]: https://doc.rust-lang.org/1.39.0/book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html
 
 </aside>
 


### PR DESCRIPTION
Updated all doc.rust-lang.org/1.31.0 links to doc.rust-lang.org/1.39.0.

With only one exception, the new links were fine with no further changes required.

The one exception was the "Packages, Crates, and Modules" chapter was renamed, which caused the name of the link to change with it.
