### PR TITLE
Update assert_cmd testing examples to use cargo_bin()

### DIFF
--- a/src/tutorial/testing.md
+++ b/src/tutorial/testing.md
@@ -429,7 +429,7 @@ You can run this test with
 `cargo test`,
 just the tests we wrote above.
 It might take a little longer the first time,
-as `Command::main_binary()` needs to compile your main binary.
+as `Command::cargo_bin("grrs")` needs to compile your main binary.
 
 ## Generating test files
 

--- a/src/tutorial/testing/tests/cli.rs
+++ b/src/tutorial/testing/tests/cli.rs
@@ -4,7 +4,7 @@ use predicates::prelude::*; // Used for writing assertions
 
 #[test]
 fn file_doesnt_exist() -> Result<(), Box<std::error::Error>> {
-    let mut cmd = Command::main_binary()?;
+    let mut cmd = Command::cargo_bin("grrs")?;
     cmd.arg("foobar")
         .arg("test/file/doesnt/exist");
     cmd.assert()
@@ -22,7 +22,7 @@ fn find_content_in_file() -> Result<(), Box<std::error::Error>> {
     let mut file = NamedTempFile::new()?;
     writeln!(file, "A test\nActual content\nMore content\nAnother test")?;
 
-    let mut cmd = Command::main_binary()?;
+    let mut cmd = Command::cargo_bin("grrs")?;
     cmd.arg("test")
         .arg(file.path());
     cmd.assert()


### PR DESCRIPTION
As of [version 0.11.0](https://docs.rs/assert_cmd/0.11.0/assert_cmd/cargo/trait.CommandCargoExt.html#tymethod.cargo_bin), the assert_cmd crate has dropped the
`main_binary()` function in favor of `cargo_bin()` that takes the name
of the cargo binary. Update the testing chapter of the book to use
`cargo_bin("grrs")` with the binary name hard coded. Another option
would be to use `cargo_bin(env!("CARGO_PKG_NAME"))` if you briefly
wanted to explain cargo's environmental variables and the `env!()` macro.